### PR TITLE
Fix pnpm workspace packages field for Docker builds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+packages: []
+
 ignoredBuiltDependencies:
   - sharp
   - unrs-resolver


### PR DESCRIPTION
## Summary
- Add `packages: []` to `pnpm-workspace.yaml` so Nixpacks/Coolify `pnpm i --frozen-lockfile` stops failing with `packages field missing or empty`

## Test plan
- [ ] Redeploy peon-website on Coolify and confirm install/build succeeds


Made with [Cursor](https://cursor.com)