### PR TITLE
Add Product Hunt badge to footer

### DIFF
--- a/src/components/marketing/site-footer.tsx
+++ b/src/components/marketing/site-footer.tsx
@@ -69,6 +69,20 @@ export function SiteFooter() {
               Open-source deployment platform. Your servers, our pipelines. $3 per project
               or free self-host.
             </p>
+            <a
+              href="https://www.producthunt.com/products/peon?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-peon"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-4 inline-block transition-opacity hover:opacity-80"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                alt="Peon - Open source alternative to Vercel, Heroku, Netlify. | Product Hunt"
+                width={250}
+                height={54}
+                src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1206439&theme=light&t=1785051322486"
+              />
+            </a>
           </div>
           <FooterColumn title="Product" links={PRODUCT} />
           <FooterColumn title="Compare" links={COMPARE} />


### PR DESCRIPTION
## Summary
- Adds the Product Hunt featured badge under the Peon blurb in `SiteFooter` so it appears site-wide without crowding the hero.

## Test plan
- [ ] Load homepage and confirm badge renders in the footer brand column
- [ ] Click badge and confirm it opens the Peon Product Hunt page in a new tab
- [ ] Spot-check another page (docs/blog) that uses `SiteFooter`


Made with [Cursor](https://cursor.com)