### PR TITLE
feat: capture and forward first-touch marketing attribution

### DIFF
--- a/src/app/blogs/[slug]/page.tsx
+++ b/src/app/blogs/[slug]/page.tsx
@@ -8,7 +8,8 @@ import {
   getPublishedPost,
   relatedPublishedPosts,
 } from '@/lib/blog';
-import { appHref, publicEnv } from '@/lib/env';
+import { AppCtaLink } from '@/components/marketing/app-cta-link';
+import { publicEnv } from '@/lib/env';
 
 export const dynamic = 'force-dynamic';
 
@@ -128,12 +129,12 @@ export default async function BlogPostPage({ params }: Props) {
             Peon is the open-source deployment platform: git push to deploy, automatic HTTPS,
             managed databases with backups - $3 per project, unlimited team members.
           </p>
-          <Link
-            href={appHref('/register')}
+          <AppCtaLink
+            path="/register"
             className="mt-5 inline-block rounded-md bg-primary px-6 py-2.5 text-sm font-semibold text-primary-foreground hover:opacity-90"
           >
             Start deploying for $3
-          </Link>
+          </AppCtaLink>
         </aside>
 
         {related.length > 0 ? (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import {
   GoogleTagManager,
   GoogleTagManagerNoscript,
 } from '@/components/analytics/google-tag-manager';
+import { AttributionCapture } from '@/components/analytics/attribution-capture';
 import { cn } from '@/lib/utils';
 import { publicEnv } from '@/lib/env';
 import './globals.css';
@@ -55,6 +56,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body>
         <GoogleTagManagerNoscript />
         <GoogleTagManager />
+        <AttributionCapture />
         <ThemeProvider>
           <MarketingTheme>
             <div className="bg-background text-foreground min-h-screen">{children}</div>

--- a/src/app/open-source/page.tsx
+++ b/src/app/open-source/page.tsx
@@ -4,7 +4,7 @@ import { SiteHeader } from '@/components/marketing/site-header';
 import { SiteFooter } from '@/components/marketing/site-footer';
 import { GithubIcon } from '@/components/icons/github';
 import { SPONSOR_LINKS, VISIBLE_SPONSOR_CHANNELS } from '@/lib/sponsors';
-import { appHref } from '@/lib/env';
+import { AppCtaLink } from '@/components/marketing/app-cta-link';
 
 export const dynamic = 'force-static';
 
@@ -167,12 +167,12 @@ export default function OpenSourcePage() {
                 <h3 className="font-heading text-base font-700 text-phosphor">Hosted services</h3>
                 <p className="mt-2 text-sm leading-relaxed text-muted-foreground sm:text-base">
                   Prefer not to operate the control plane?{' '}
-                  <a
-                    href={appHref('/register')}
+                  <AppCtaLink
+                    path="/register"
                     className="text-phosphor underline-offset-4 hover:underline"
                   >
                     Peon Cloud
-                  </a>{' '}
+                  </AppCtaLink>{' '}
                   is $3 per project per month or $30 per year with unlimited servers and seats.
                   Same product features; we run the dashboard and updates. Revenue funds
                   continued open-source development.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,7 +14,7 @@ import {
 import Link from "next/link"
 import { SiteHeader } from "@/components/marketing/site-header"
 import { SiteFooter } from "@/components/marketing/site-footer"
-import { appHref } from "@/lib/env"
+import { AppCtaLink } from "@/components/marketing/app-cta-link"
 
 /** Fully static HTML for crawlers (incl. Google OAuth brand verification). */
 export const dynamic = "force-static"
@@ -327,12 +327,12 @@ export default function LandingPage() {
               Open source · self-host free · cloud from $3 / mo or $30 / yr
             </p>
             <div className="mt-8 flex flex-wrap items-center justify-center gap-4">
-              <Link
-                href={appHref("/register")}
+              <AppCtaLink
+                path="/register"
                 className="rounded-md bg-primary px-6 py-3 text-sm font-semibold text-primary-foreground hover:opacity-90"
               >
                 Deploy your first project - $3
-              </Link>
+              </AppCtaLink>
               <a
                 href="#compare"
                 className="rounded-md border border-border-bright px-6 py-3 text-sm font-semibold hover:bg-accent"
@@ -635,12 +635,12 @@ export default function LandingPage() {
                     </li>
                   ))}
                 </ul>
-                <Link
-                  href={appHref("/register")}
+                <AppCtaLink
+                  path="/register"
                   className="mt-8 block rounded-md bg-primary px-6 py-3 text-center text-sm font-semibold text-primary-foreground hover:opacity-90"
                 >
                   Create your first project
-                </Link>
+                </AppCtaLink>
               </div>
 
               {/* Enterprise */}
@@ -719,12 +719,12 @@ export default function LandingPage() {
             <p className="mt-4 max-w-xl text-muted-foreground">
               Connect a server, push your code, and go live in minutes - for the price of a coffee refill.
             </p>
-            <Link
-              href={appHref("/register")}
+            <AppCtaLink
+              path="/register"
               className="mt-8 rounded-md bg-primary px-8 py-3 text-sm font-semibold text-primary-foreground hover:opacity-90"
             >
               Start deploying for $3
-            </Link>
+            </AppCtaLink>
           </div>
         </section>
       </main>

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -67,6 +67,7 @@ export default function PrivacyPolicyPage() {
           title: 'Cookies and similar technologies',
           paragraphs: [
             'We use cookies and similar technologies that are necessary for authentication, session management, security, and remembering preferences. We do not use third-party advertising cookies on peon.sh or app.peon.sh.',
+            'We may set a first-party cookie (shared across peon.sh and app.peon.sh) to remember the marketing campaign or referral parameters from your first visit (for example utm_source or a product-hunt ref). We use this only to measure how people discover Peon and to attribute signups to a campaign. It is not used for third-party advertising or cross-site tracking.',
             'If we introduce optional analytics in the future, we will update this policy and, where required, provide choices consistent with applicable law.',
           ],
         },

--- a/src/components/analytics/attribution-capture.tsx
+++ b/src/components/analytics/attribution-capture.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { useEffect } from 'react';
+import { captureFirstTouchAttribution } from '@/lib/attribution';
+
+/** Capture first-touch campaign params into the peon_attr cookie on mount. */
+export function AttributionCapture() {
+  useEffect(() => {
+    captureFirstTouchAttribution();
+  }, []);
+  return null;
+}

--- a/src/components/marketing/app-cta-link.tsx
+++ b/src/components/marketing/app-cta-link.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect, useState, type ComponentPropsWithoutRef } from 'react';
+import { appHref } from '@/lib/env';
+import { withAttributionQuery } from '@/lib/attribution';
+
+type Props = Omit<ComponentPropsWithoutRef<'a'>, 'href'> & {
+  /** Path on the Peon app, e.g. `/register` or `/login`. */
+  path: string;
+};
+
+/**
+ * Link to the Peon app that appends first-touch attribution query params
+ * (from cookie or current page search) at render time.
+ */
+export function AppCtaLink({ path, children, ...rest }: Props) {
+  const bare = appHref(path);
+  const [href, setHref] = useState(bare);
+
+  useEffect(() => {
+    setHref(withAttributionQuery(bare));
+  }, [bare]);
+
+  return (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  );
+}

--- a/src/components/marketing/app-cta-link.tsx
+++ b/src/components/marketing/app-cta-link.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, type ComponentPropsWithoutRef } from 'react';
+import { useSyncExternalStore, type ComponentPropsWithoutRef } from 'react';
 import { appHref } from '@/lib/env';
 import { withAttributionQuery } from '@/lib/attribution';
 
@@ -9,17 +9,21 @@ type Props = Omit<ComponentPropsWithoutRef<'a'>, 'href'> & {
   path: string;
 };
 
+function subscribeNoop() {
+  return () => {};
+}
+
 /**
  * Link to the Peon app that appends first-touch attribution query params
- * (from cookie or current page search) at render time.
+ * (from cookie or current page search) after mount.
  */
 export function AppCtaLink({ path, children, ...rest }: Props) {
   const bare = appHref(path);
-  const [href, setHref] = useState(bare);
-
-  useEffect(() => {
-    setHref(withAttributionQuery(bare));
-  }, [bare]);
+  const href = useSyncExternalStore(
+    subscribeNoop,
+    () => withAttributionQuery(bare),
+    () => bare,
+  );
 
   return (
     <a href={href} {...rest}>

--- a/src/components/marketing/marketplace-grid.tsx
+++ b/src/components/marketing/marketplace-grid.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import type { TemplateSummary } from '@/lib/templates';
-import { appHref } from '@/lib/env';
+import { AppCtaLink } from '@/components/marketing/app-cta-link';
 
 /**
  * Client-side searchable grid for the public marketplace. Deploy links go to
@@ -92,12 +92,12 @@ export function MarketplaceGrid({
               </div>
             </div>
             <div className="mt-4 flex flex-1 items-end justify-between">
-              <a
-                href={appHref(`/deploy/${t.slug}`)}
+              <AppCtaLink
+                path={`/deploy/${t.slug}`}
                 className="bg-primary text-primary-foreground rounded-md px-3 py-1.5 text-xs font-semibold hover:opacity-90"
               >
                 Deploy
-              </a>
+              </AppCtaLink>
               {t.documentation && (
                 <a
                   href={t.documentation}

--- a/src/components/marketing/seo-page.tsx
+++ b/src/components/marketing/seo-page.tsx
@@ -1,13 +1,17 @@
 import Link from 'next/link';
 import { SiteHeader } from '@/components/marketing/site-header';
 import { SiteFooter } from '@/components/marketing/site-footer';
+import { AppCtaLink } from '@/components/marketing/app-cta-link';
 import type { SeoPage as SeoPageData } from '@/lib/seo-pages';
-import { appHref } from '@/lib/env';
+import { appHref, publicEnv } from '@/lib/env';
 
 export function SeoMarketingPage({ page }: { page: SeoPageData }) {
   const ctaHref = page.ctaHref ?? appHref('/register');
   const ctaLabel = page.ctaLabel ?? 'Start deploying';
-  const isExternal = ctaHref.startsWith('http') || ctaHref.startsWith('mailto:');
+  const isMailto = ctaHref.startsWith('mailto:');
+  const isAppCta = ctaHref.startsWith(publicEnv.appUrl);
+  const appPath = isAppCta ? ctaHref.slice(publicEnv.appUrl.length) || '/' : null;
+  const isExternal = !isAppCta && (ctaHref.startsWith('http') || isMailto);
 
   const jsonLd = {
     '@context': 'https://schema.org',
@@ -40,7 +44,14 @@ export function SeoMarketingPage({ page }: { page: SeoPageData }) {
               {page.intro}
             </p>
             <div className="mt-8">
-              {isExternal ? (
+              {appPath ? (
+                <AppCtaLink
+                  path={appPath}
+                  className="inline-flex rounded-md bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground hover:opacity-90"
+                >
+                  {ctaLabel}
+                </AppCtaLink>
+              ) : isExternal ? (
                 <a
                   href={ctaHref}
                   className="inline-flex rounded-md bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground hover:opacity-90"

--- a/src/components/marketing/site-footer.tsx
+++ b/src/components/marketing/site-footer.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { appHref } from '@/lib/env';
+import { AppCtaLink } from '@/components/marketing/app-cta-link';
 
 const PRODUCT = [
   { label: 'Features', href: '/#features' },
@@ -26,7 +26,7 @@ const RESOURCES = [
   { label: 'Blog', href: '/blogs' },
   { label: 'Privacy', href: '/privacy-policy' },
   { label: 'Terms', href: '/terms-of-services' },
-  { label: 'Log in', href: appHref('/login'), external: true },
+  { label: 'Log in', href: '/login', app: true },
 ];
 
 function FooterColumn({
@@ -34,7 +34,7 @@ function FooterColumn({
   links,
 }: {
   title: string;
-  links: { label: string; href: string; external?: boolean }[];
+  links: { label: string; href: string; app?: boolean }[];
 }) {
   return (
     <div>
@@ -42,10 +42,10 @@ function FooterColumn({
       <ul className="mt-3 space-y-2">
         {links.map((link) => (
           <li key={`${link.href}-${link.label}`}>
-            {link.external ? (
-              <a href={link.href} className="hover:text-foreground">
+            {link.app ? (
+              <AppCtaLink path={link.href} className="hover:text-foreground">
                 {link.label}
-              </a>
+              </AppCtaLink>
             ) : (
               <Link href={link.href} className="hover:text-foreground">
                 {link.label}

--- a/src/components/marketing/site-header.tsx
+++ b/src/components/marketing/site-header.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { LogoMark } from '@/components/logo';
 import { GithubIcon } from '@/components/icons/github';
-import { appHref } from '@/lib/env';
+import { AppCtaLink } from '@/components/marketing/app-cta-link';
 
 const NAV_ITEMS = [
   { label: 'Features', href: '/#features' },
@@ -71,12 +71,12 @@ export function SiteHeader({
           })}
         </div>
 
-        <a
-          href={appHref('/login')}
+        <AppCtaLink
+          path="/login"
           className="bg-primary text-primary-foreground rounded-md px-3 py-1.5 text-sm font-semibold hover:opacity-90"
         >
           Log in
-        </a>
+        </AppCtaLink>
       </nav>
     </header>
   );

--- a/src/lib/attribution.ts
+++ b/src/lib/attribution.ts
@@ -1,0 +1,191 @@
+/**
+ * First-touch marketing attribution for peon.sh → app.peon.sh.
+ *
+ * Captures campaign query params into a first-party cookie (Domain=.peon.sh when
+ * on peon.sh) so browsing the marketing site and crossing to the app does not
+ * drop the funnel source. Cookie is write-once (first-touch).
+ */
+
+export const ATTRIBUTION_COOKIE = 'peon_attr';
+export const ATTRIBUTION_MAX_AGE_SEC = 90 * 24 * 60 * 60;
+export const ATTRIBUTION_VALUE_MAX = 200;
+
+/** Query keys we persist and forward. */
+export const ATTRIBUTION_QUERY_KEYS = [
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_content',
+  'utm_term',
+  'ref',
+  'gclid',
+  'fbclid',
+  'msclkid',
+  'campaign',
+] as const;
+
+export type AttributionQueryKey = (typeof ATTRIBUTION_QUERY_KEYS)[number];
+
+export type AttributionPayload = {
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  utm_content?: string;
+  utm_term?: string;
+  ref?: string;
+  gclid?: string;
+  fbclid?: string;
+  msclkid?: string;
+  campaign?: string;
+  landing_path?: string;
+  captured_at?: string;
+};
+
+const KEY_SET = new Set<string>(ATTRIBUTION_QUERY_KEYS);
+
+function sanitizeValue(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  if (trimmed.length > ATTRIBUTION_VALUE_MAX) return trimmed.slice(0, ATTRIBUTION_VALUE_MAX);
+  return trimmed;
+}
+
+/** Parse attribution fields from a URLSearchParams / query string. */
+export function parseAttributionParams(
+  search: string | URLSearchParams,
+): AttributionPayload | null {
+  const params = typeof search === 'string' ? new URLSearchParams(search) : search;
+  const out: AttributionPayload = {};
+  let found = false;
+  for (const key of ATTRIBUTION_QUERY_KEYS) {
+    const value = params.get(key);
+    if (value == null) continue;
+    const clean = sanitizeValue(value);
+    if (!clean) continue;
+    out[key] = clean;
+    found = true;
+  }
+  return found ? out : null;
+}
+
+export function hasAttributionFields(payload: AttributionPayload | null | undefined): boolean {
+  if (!payload) return false;
+  return ATTRIBUTION_QUERY_KEYS.some((k) => Boolean(payload[k]));
+}
+
+/** Cookie Domain for shared peon.sh / app.peon.sh; omit on localhost. */
+export function attributionCookieDomain(hostname: string): string | undefined {
+  const host = hostname.toLowerCase();
+  if (host === 'peon.sh' || host.endsWith('.peon.sh')) return '.peon.sh';
+  return undefined;
+}
+
+export function readAttributionCookie(): AttributionPayload | null {
+  if (typeof document === 'undefined') return null;
+  const match = document.cookie
+    .split(';')
+    .map((c) => c.trim())
+    .find((c) => c.startsWith(`${ATTRIBUTION_COOKIE}=`));
+  if (!match) return null;
+  const raw = match.slice(ATTRIBUTION_COOKIE.length + 1);
+  try {
+    const parsed = JSON.parse(decodeURIComponent(raw)) as AttributionPayload;
+    if (!parsed || typeof parsed !== 'object') return null;
+    return sanitizePayload(parsed);
+  } catch {
+    return null;
+  }
+}
+
+function sanitizePayload(input: AttributionPayload): AttributionPayload | null {
+  const out: AttributionPayload = {};
+  let found = false;
+  for (const key of ATTRIBUTION_QUERY_KEYS) {
+    const value = input[key];
+    if (typeof value !== 'string') continue;
+    const clean = sanitizeValue(value);
+    if (!clean) continue;
+    out[key] = clean;
+    found = true;
+  }
+  if (typeof input.landing_path === 'string' && input.landing_path) {
+    out.landing_path = sanitizeValue(input.landing_path) ?? undefined;
+  }
+  if (typeof input.captured_at === 'string' && input.captured_at) {
+    out.captured_at = input.captured_at.slice(0, 40);
+  }
+  return found ? out : null;
+}
+
+/**
+ * Write first-touch cookie. No-op if a cookie already exists or payload is empty.
+ * Returns true when a new cookie was written.
+ */
+export function captureFirstTouchAttribution(opts?: {
+  search?: string | URLSearchParams;
+  pathname?: string;
+}): boolean {
+  if (typeof document === 'undefined' || typeof window === 'undefined') return false;
+  if (readAttributionCookie()) return false;
+
+  const fromQuery = parseAttributionParams(opts?.search ?? window.location.search);
+  if (!fromQuery) return false;
+
+  const payload: AttributionPayload = {
+    ...fromQuery,
+    landing_path: sanitizeValue(opts?.pathname ?? window.location.pathname) ?? '/',
+    captured_at: new Date().toISOString(),
+  };
+
+  const encoded = encodeURIComponent(JSON.stringify(payload));
+  const domain = attributionCookieDomain(window.location.hostname);
+  const parts = [
+    `${ATTRIBUTION_COOKIE}=${encoded}`,
+    'Path=/',
+    `Max-Age=${ATTRIBUTION_MAX_AGE_SEC}`,
+    'SameSite=Lax',
+  ];
+  if (window.location.protocol === 'https:') parts.push('Secure');
+  if (domain) parts.push(`Domain=${domain}`);
+  document.cookie = parts.join('; ');
+  return true;
+}
+
+/** Merge attribution into an absolute app URL (or path). Prefers cookie, then page search. */
+export function withAttributionQuery(
+  href: string,
+  opts?: { search?: string | URLSearchParams },
+): string {
+  const fromCookie = readAttributionCookie();
+  const fromPage = parseAttributionParams(opts?.search ?? (typeof window !== 'undefined' ? window.location.search : ''));
+  const source = fromCookie ?? fromPage;
+  if (!source || !hasAttributionFields(source)) return href;
+
+  try {
+    const url = new URL(href, typeof window !== 'undefined' ? window.location.origin : 'https://app.peon.sh');
+    for (const key of ATTRIBUTION_QUERY_KEYS) {
+      const value = source[key];
+      if (value && !url.searchParams.has(key)) {
+        url.searchParams.set(key, value);
+      }
+    }
+    // Absolute href that was already absolute: keep origin+path+search.
+    if (/^https?:\/\//i.test(href)) {
+      return url.toString();
+    }
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return href;
+  }
+}
+
+/** Drop unknown keys from a loose object (for tests / debugging). */
+export function pickAttributionKeys(input: Record<string, unknown>): AttributionPayload {
+  const out: AttributionPayload = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (!KEY_SET.has(key) || typeof value !== 'string') continue;
+    const clean = sanitizeValue(value);
+    if (clean) out[key as AttributionQueryKey] = clean;
+  }
+  return out;
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -8,7 +8,11 @@ export const publicEnv = {
   gtmId: (process.env.NEXT_PUBLIC_GTM_ID ?? '').trim(),
 };
 
-/** Absolute URL into the Peon app. */
+/**
+ * Absolute URL into the Peon app.
+ * For marketing CTAs that should carry first-touch UTMs, prefer `<AppCtaLink path=… />`
+ * (client) which merges the peon_attr cookie / page query onto this base URL.
+ */
 export function appHref(path: string): string {
   const p = path.startsWith('/') ? path : `/${path}`;
   return `${publicEnv.appUrl}${p}`;


### PR DESCRIPTION
## Summary
- First-touch `peon_attr` cookie (`Domain=.peon.sh`, 90d) from allowlisted campaign params
- `AppCtaLink` appends attribution on register/login/deploy CTAs
- Privacy policy notes the first-party attribution cookie

Pairs with the peon-app PR that persists attribution at signup.

## Test plan
- [ ] Open `https://peon.sh/?utm_source=ph&utm_medium=social&utm_campaign=test`
- [ ] Confirm `peon_attr` cookie is set; browse another page without overwrite
- [ ] Click Register / Log in → app URL includes UTMs
- [ ] Marketplace Deploy links also carry params
- [ ] Privacy policy mentions attribution cookie
- [ ] `pnpm exec tsc --noEmit`


Made with [Cursor](https://cursor.com)